### PR TITLE
Introduce cli main to orchestrate args, prompt, and core execution

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,0 +1,135 @@
+"""
+cli/main.py
+
+TablePick CLI の実行エントリポイント。
+- args.py: 引数定義・設定生成
+- prompt.py: 未指定の重要引数を対話で補完
+- core: fetch / convert / output を実行
+
+終了コード（目安）:
+- 0: 成功
+- 1: 想定内エラー（入力不備、取得失敗、テーブル無し等）
+- 2: 想定外エラー
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Optional, Sequence
+
+from core import HtmlFetcher
+from core.converter import HtmlTableConverter
+from core.output import TableOutputWriter
+
+from . import args as cli_args
+from . import prompt as cli_prompt
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    argv_list = list(argv) if argv is not None else sys.argv[1:]
+
+    try:
+        # 1) 足りない重要オプションを対話補完し、argv を拡張
+        argv_list = _maybe_prompt_and_extend_argv(argv_list)
+
+        # 2) 最終パース
+        ns = cli_args.parse_args(argv_list)
+
+        # 3) debug（stderr）
+        if getattr(ns, "debug", False):
+            _print_debug(ns)
+
+        # 4) core 実行パイプライン
+        fetch_config = cli_args.make_fetch_config(ns)
+        out_opt = cli_args.make_output_options(ns)
+
+        # HtmlFetcher.fetch は (html, final_url, response) を返す
+        html, final_url, response = HtmlFetcher(config=fetch_config).fetch(ns.url)
+
+        tables = HtmlTableConverter().convert(html)
+
+        writer = TableOutputWriter()
+        written = writer.emit(tables, out_opt)
+
+        # stdout を汚さないため、状況メッセージは stderr に
+        if out_opt.out_dir is not None:
+            print(f"[tablepick] wrote {len(written)} file(s) to: {out_opt.out_dir}", file=sys.stderr)
+
+        return 0
+
+    except SystemExit as e:
+        # argparse が exit するケース（invalid args）
+        code = int(e.code) if e.code is not None else 1
+        return code
+
+    except Exception as e:
+        # 例外体系は tablepick/error.py に集約される想定。
+        # ここでは stdout を汚さないよう stderr に出して exit code=1 とする。
+        print(f"[tablepick:error] {e}", file=sys.stderr)
+        return 1
+
+
+def _maybe_prompt_and_extend_argv(argv_list: list[str]) -> list[str]:
+    """
+    argv に重要オプションが不足している場合だけ prompt を起動し、
+    入力された値で argv を補完して返す。
+
+    対象（prompt.py の仕様）:
+    - --url, --format, --out-dir, --filename-base, --stdout/--no-stdout
+    """
+    argv_set = set(argv_list)
+
+    need_prompt = (
+        ("--url" not in argv_set)
+        or ("--format" not in argv_set)
+        or ("--out-dir" not in argv_set)
+        or ("--filename-base" not in argv_set)
+        or (("--stdout" not in argv_set) and ("--no-stdout" not in argv_set))
+    )
+
+    if not need_prompt:
+        return argv_list
+
+    pr = cli_prompt.fill_missing_with_prompt(
+        argv=argv_list,
+        url=None,  # --url 無しの可能性があるので None
+        fmt="csv",
+        out_dir=None,
+        filename_base="tablepick",
+        stdout=True,
+    )
+
+    extended = list(argv_list)
+
+    if "--url" not in argv_set:
+        extended += ["--url", pr.url]
+
+    if "--format" not in argv_set:
+        extended += ["--format", pr.fmt]
+
+    if "--out-dir" not in argv_set:
+        # 空入力は None（=ファイル出力しない）なので、その場合は追加しない
+        if pr.out_dir is not None:
+            extended += ["--out-dir", pr.out_dir]
+
+    if "--filename-base" not in argv_set:
+        extended += ["--filename-base", pr.filename_base]
+
+    if ("--stdout" not in argv_set) and ("--no-stdout" not in argv_set):
+        extended += ["--stdout"] if pr.stdout else ["--no-stdout"]
+
+    return extended
+
+
+def _print_debug(ns) -> None:
+    """
+    args.py の debug_dump を stderr に出す。
+    """
+    data = cli_args.debug_dump(ns)
+    print("[tablepick:debug] parsed configs:", file=sys.stderr)
+    print(json.dumps(data, ensure_ascii=False, indent=2), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要（What）

CLI 実行時のエントリポイントとして `cli/main.py` を追加しました。

本ファイルは、既存の

- 引数定義（`cli/args.py`）
- 対話入力補完（`cli/prompt.py`）
- core 層の fetch / convert / output パイプライン

を統合し、**TablePick を CLI ツールとして一貫した流れで実行できるようにする**役割を担います。

---

## 変更内容（Changes）

- `cli/main.py` を新規作成
- CLI 実行時の処理フローを実装
  1. `argv` を解析し、重要オプション不足時は `prompt.py` により対話補完
  2. `args.py` による最終的な引数パース
  3. `FetchConfig` / `OutputOptions` を生成
  4. core 層の処理を順に実行
     - HTML 取得（`HtmlFetcher`）
     - テーブル抽出・変換（`HtmlTableConverter`）
     - stdout / ファイル出力（`TableOutputWriter`）
- `--debug` 指定時に、解釈された設定内容を JSON 形式で stderr に出力
- stdout を汚さないよう、ステータスメッセージやエラーは stderr に出力
- `HtmlFetcher.fetch()` の戻り値（`html, final_url, response`）を正しく扱うように実装

---

## 設計方針（Design Policy）

- **責務分離の徹底**
  - 引数解釈：`args.py`
  - 対話入力：`prompt.py`
  - 実行制御：`main.py`
  - 実処理：`core` 配下
- **壊れにくい CLI**
  - 必須情報が不足している場合は prompt により明示的に入力させる
  - 不正入力は即エラーとして扱い、暗黙補完は行わない
- **CLI とライブラリ両立**
  - stdout はデータ出力専用とし、ログ・デバッグ情報は stderr に分離
- **将来拡張を考慮**
  - 新しいオプションや処理追加時も main.py がオーケストレーションに専念できる構造

---

## 実行フロー（Flow）

```text
CLI実行
  ↓
argv チェック
  ↓（不足時）
prompt による対話入力
  ↓
args.py で最終パース
  ↓
FetchConfig / OutputOptions 生成
  ↓
HtmlFetcher.fetch
  ↓
HtmlTableConverter.convert
  ↓
TableOutputWriter.emit
