### PR TITLE
Add cli package initializer exporting public CLI interfaces

### DIFF
--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -1,0 +1,28 @@
+"""
+cli package
+
+TablePick の CLI 層。
+- args.py   : 引数定義・設定生成
+- prompt.py : 対話入力による不足オプション補完
+- main.py   : CLI 実行のオーケストレーション（entrypoint）
+
+ここでは外部から利用しやすい最低限のAPIを re-export する。
+"""
+
+from .main import main
+from .args import build_parser, parse_args, make_fetch_config, make_output_options, debug_dump
+from .prompt import fill_missing_with_prompt, PromptResult
+
+__all__ = [
+    # entrypoint
+    "main",
+    # args helpers
+    "build_parser",
+    "parse_args",
+    "make_fetch_config",
+    "make_output_options",
+    "debug_dump",
+    # prompt helpers
+    "fill_missing_with_prompt",
+    "PromptResult",
+]


### PR DESCRIPTION
## 概要（What）

`cli` パッケージの初期化ファイルとして `cli/__init__.py` を追加しました。

CLI 層で提供する公開インターフェースを明示し、  
`args / prompt / main` を統合して外部から利用しやすくすることを目的としています。

---

## 変更内容（Changes）

- `cli/__init__.py` を新規作成
- CLI 層で利用頻度の高い関数・エントリポイントを re-export
  - `main`（CLI 実行エントリポイント）
  - 引数関連ユーティリティ（`args.py`）
  - 対話入力補完ユーティリティ（`prompt.py`）
- `__all__` を定義し、CLI パッケージとしての公開範囲を明確化

---

## 設計方針（Design Policy）

- **責務分離の維持**
  - 実装の詳細は各モジュール（`args.py` / `prompt.py` / `main.py`）に委譲
  - `__init__.py` は「公開APIの整理」にのみ責務を限定
- **副作用を持たない初期化**
  - パーサ生成や実行処理は import 時に行わず、関数呼び出し時に実行
- **将来拡張を考慮**
  - `tablepick/__main__.py` や entrypoint 設定から
    `from cli import main` の形で自然に接続可能

---

## 影響範囲（Impact）

- 既存の CLI / core の挙動に変更なし
- CLI 層の構造が明確になり、再利用・テスト・拡張が容易になる

---

## 補足（Notes）

- 次のステップとして
  - `tablepick/__main__.py` から `cli.main` を呼び出す対応
  - `pyproject.toml` での console_scripts 設定
  を検討予定
