### PR TITLE
Add tablepick package initializer (__init__.py)

### DIFF
--- a/src/tablepick/__init__.py
+++ b/src/tablepick/__init__.py
@@ -1,13 +1,35 @@
-from dataclasses import dataclass
+"""
+tablepick package
 
-@dataclass(frozen=True)
-class FetchConfig:
-    timeout: int = 10
-    retries: int = 0
-    retry_interval: int = 10
-    max_redirects: int = 3
+公開方針:
+- 例外クラスは tablepick.error に集約しており、ここからも再exportする。
+- 実処理（変換・取得・出力）は core/cli にあり、ここでは公開APIを最小に保つ。
+"""
 
+from __future__ import annotations
 
-from .get_html import HtmlFetcher
+# Version
+__all__ = [
+    "__version__",
+    # errors (re-export)
+    "TablePickError",
+    "NoTableFoundError",
+    "TableConversionError",
+    "FetchError",
+    "OutputError",
+    "UnsupportedFormatError",
+    "NoTablesToOutputError",
+]
 
-__all__ = ["FetchConfig", "HtmlFetcher"]
+__version__ = "0.1.0"
+
+# Re-export errors for convenient import: `from tablepick import TablePickError`
+from .error import (  # noqa: E402
+    FetchError,
+    NoTableFoundError,
+    NoTablesToOutputError,
+    OutputError,
+    TableConversionError,
+    TablePickError,
+    UnsupportedFormatError,
+)


### PR DESCRIPTION
## 概要
- tablepick/__init__.py を追加し、パッケージの公開インターフェースを整備しました。

## 背景
- TablePick の例外体系は tablepick/error.py に集約する方針のため、
  利用者が `from tablepick import ...` で例外を扱えるよう再exportを提供します。
- 併せてパッケージとしての最小限のメタ情報（version）を定義します。

## 変更内容
- tablepick/__init__.py を新規追加
- __version__ を定義
- tablepick.error の例外クラスを tablepick 直下から import できるよう再export
  - TablePickError
  - NoTableFoundError / TableConversionError
  - FetchError
  - OutputError / UnsupportedFormatError / NoTablesToOutputError

## 設計上のポイント
- 公開APIを最小に保ちつつ、例外は利用しやすい形で提供
- 実処理（core/cli）には踏み込まず、責務を増やさない

## 影響範囲
- 新規ファイル追加のみ
- 既存ロジックの挙動変更なし

## 動作確認
- `python -c "import tablepick; print(tablepick.__version__)"`
- `python -c "from tablepick import TablePickError; print(TablePickError)"`
