### PR TITLE
fix: update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,29 @@ dependencies = [
   "beautifulsoup4",
   "requests",
 ]
+license = {text = "MIT"}
+authors = [
+  {name = "koume-z"},
+]
+keywords = ["html", "table", "csv", "json", "scraping"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Text Processing",
+]
+
+[project.urls]
+Repository = "https://github.com/koume-z/TablePick"
+Issues = "https://github.com/koume-z/TablePick/issues"
+
+[project.scripts]
+tablepick = "tablepick.cli.main:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## 概要
tablepickコマンドを使用可能にするため`pyproject.toml` を修正しました。

## 変更内容
- ライセンス情報を明示（LICENSE ファイル参照）
- authors を GitHub アカウント基準で定義
- project.urls を GitHub リポジトリ／Issues に統一
- project.scripts を追加

## 目的
- tablepickコマンドを使用可能にするため

## 影響範囲
- 実行コードへの影響なし
- ビルド・配布設定のみ変更

## 確認事項
- `pip install -e .` が正常に実行できること
- CLI コマンドが従来どおり動作すること